### PR TITLE
Compose Unity into SwiftUI whenever internal superview is changed

### DIFF
--- a/sandbox/sandbox.xcodeproj/project.pbxproj
+++ b/sandbox/sandbox.xcodeproj/project.pbxproj
@@ -310,7 +310,7 @@
 				DEVELOPMENT_TEAM = X69FKJ5KGT;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = sandbox/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -333,7 +333,7 @@
 				DEVELOPMENT_TEAM = X69FKJ5KGT;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = sandbox/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/sandbox/sandbox/ContentView.swift
+++ b/sandbox/sandbox/ContentView.swift
@@ -15,8 +15,7 @@ struct UnityView: UIViewControllerRepresentable {
         UnityBridge.getInstance().superview = vc.view
         UnityBridge.getInstance().onReady = {
             print("Unity is now ready!")
-            let api = UnityBridge.getInstance().api
-            api.test("This string travels far, far away toward Unity")
+            UnityBridge.getInstance().api.test("This string travels far, far away toward Unity")
         }
 
         return vc
@@ -58,7 +57,9 @@ struct ContentView: View {
              Library only supports full-screen rendering, and doesn’t support rendering on
              part of the screen.", but we have overcome this limitation. */
 
-            Text("This text overlaps Unity!")
+            Button("This button overlaps Unity!", action: {
+                UnityBridge.getInstance().api.test("Native button pressed!")
+            }).buttonStyle(.borderedProminent).tint(.blue)
         }
     }
 }

--- a/sandbox/sandbox/ContentView.swift
+++ b/sandbox/sandbox/ContentView.swift
@@ -44,7 +44,7 @@ struct ContentView: View {
     
     var body: some View {
         ZStack {
-            UnityView()
+            UnityView().ignoresSafeArea()
 
             // OtherUnityView().frame(width: 200, height: 200, alignment: .center).offset(x: 100, y: 0)
             /* Uncomment the above line to see that we can swap UnityBridge to another view

--- a/sandbox/sandbox/ContentView.swift
+++ b/sandbox/sandbox/ContentView.swift
@@ -33,6 +33,12 @@ struct OtherUnityView: UIViewControllerRepresentable {
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
             UnityBridge.getInstance().superview = vc.view
         }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 8.0) {
+            UnityBridge.getInstance().superview = nil
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 11.0) {
+            UnityBridge.getInstance().superview = vc.view
+        }
 
         return vc
     }

--- a/sandbox/sandbox/ContentView.swift
+++ b/sandbox/sandbox/ContentView.swift
@@ -7,29 +7,51 @@
 
 import SwiftUI
 
-struct MyViewController: UIViewControllerRepresentable {
+struct UnityView: UIViewControllerRepresentable {
 
-  func makeUIViewController(context: Context) -> UIViewController {
-    let vc = UIViewController()
-    
-    UnityBridge.getInstance().onReady = {
-        print("Unity is now ready!")
-        UnityBridge.getInstance().show(controller: vc)
-        let api = UnityBridge.getInstance().api
-        api.test("This string travels far, far away toward Unity")
+    func makeUIViewController(context: Context) -> UIViewController {
+        let vc = UIViewController()
+
+        UnityBridge.getInstance().superview = vc.view
+        UnityBridge.getInstance().onReady = {
+            print("Unity is now ready!")
+            let api = UnityBridge.getInstance().api
+            api.test("This string travels far, far away toward Unity")
+        }
+
+        return vc
     }
 
-    return vc
-  }
+    func updateUIViewController(_ viewController: UIViewController, context: Context) {}
+}
 
-  func updateUIViewController(_ viewController: UIViewController, context: Context) {}
+struct OtherUnityView: UIViewControllerRepresentable {
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        let vc = UIViewController()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+            UnityBridge.getInstance().superview = vc.view
+        }
+
+        return vc
+    }
+
+    func updateUIViewController(_ viewController: UIViewController, context: Context) {}
 }
 
 struct ContentView: View {
     
     var body: some View {
         ZStack {
-            MyViewController()
+            UnityView()
+
+            // OtherUnityView().frame(width: 200, height: 200, alignment: .center).offset(x: 100, y: 0)
+            /* Uncomment the above line to see that we can swap UnityBridge to another view
+             and control its size and position. Unity's documentation says that "Unity as a
+             Library only supports full-screen rendering, and doesn’t support rendering on
+             part of the screen.", but we have overcome this limitation. */
+
             Text("This text overlaps Unity!")
         }
     }

--- a/sandbox/sandbox/UnityBridge.swift
+++ b/sandbox/sandbox/UnityBridge.swift
@@ -51,10 +51,13 @@ class UnityBridge: UIResponder, UIApplicationDelegate, UnityFrameworkListener {
     public var onReady: () -> () = {}
     public var superview: UIView? {
         didSet {
+            // remove old observation
             observation?.invalidate()
 
-            if superview != nil {
-                // register new observer; it fires on register and on new value at .rootViewController
+            if superview == nil {
+                ufw.appController()?.window.rootViewController?.view.removeFromSuperview()
+            } else {
+                // register new observation; it fires on register and on new value at .rootViewController
                 observation = ufw.appController()?.window.observe(\.rootViewController, options: [.initial, .new], changeHandler: subviewUnity)
             }
         }

--- a/sandbox/sandbox/UnityBridge.swift
+++ b/sandbox/sandbox/UnityBridge.swift
@@ -73,9 +73,7 @@ class UnityBridge: UIResponder, UIApplicationDelegate, UnityFrameworkListener {
     private static func loadUnityFramework() -> UnityFramework? {
         let bundlePath: String = Bundle.main.bundlePath + "/Frameworks/UnityFramework.framework"
         let bundle = Bundle(path: bundlePath)
-        if bundle?.isLoaded == false {
-            bundle?.load()
-        }
+        bundle?.load()
    
         let ufw = bundle?.principalClass?.getInstance()
         if ufw?.appController() == nil {

--- a/sandbox/sandbox/UnityBridge.swift
+++ b/sandbox/sandbox/UnityBridge.swift
@@ -12,14 +12,14 @@ class API: NativeCallsProtocol {
         Function pointers to static functions declared in Unity
      */
     
-    private var testCallback: TestDelegate!
+    private var testCallback: TestDelegate?
     
     /**
         Public API
      */
     
     public func test(_ value: String) {
-        self.testCallback(value)
+        self.testCallback?(value)
     }
     
     /**

--- a/sandbox/sandbox/UnityBridge.swift
+++ b/sandbox/sandbox/UnityBridge.swift
@@ -58,7 +58,7 @@ class UnityBridge: UIResponder, UIApplicationDelegate, UnityFrameworkListener {
                 ufw.appController().window.rootViewController?.view.removeFromSuperview()
             } else {
                 // register new observation; it fires on register and on new value at .rootViewController
-                observation = ufw.appController().window.observe(\.rootViewController, options: [.initial, .new], changeHandler: { [weak self] (window, _) in
+                observation = ufw.appController().window.observe(\.rootViewController, options: [.initial], changeHandler: { [weak self] (window, _) in
                     if let superview = self?.superview, let view = window.rootViewController?.view {
                         // the rootViewController of Unity's window has been assigned
                         // now is the proper moment to apply our superview if we have one

--- a/sandbox/sandbox/UnityBridge.swift
+++ b/sandbox/sandbox/UnityBridge.swift
@@ -55,10 +55,10 @@ class UnityBridge: UIResponder, UIApplicationDelegate, UnityFrameworkListener {
             observation?.invalidate()
 
             if superview == nil {
-                ufw.appController()?.window.rootViewController?.view.removeFromSuperview()
+                ufw.appController().window.rootViewController?.view.removeFromSuperview()
             } else {
                 // register new observation; it fires on register and on new value at .rootViewController
-                observation = ufw.appController()?.window.observe(\.rootViewController, options: [.initial, .new], changeHandler: subviewUnity)
+                observation = ufw.appController().window.observe(\.rootViewController, options: [.initial, .new], changeHandler: subviewUnity)
             }
         }
     }
@@ -95,12 +95,13 @@ class UnityBridge: UIResponder, UIApplicationDelegate, UnityFrameworkListener {
         self.ufw.register(self)
         FrameworkLibAPI.registerAPIforNativeCalls(self.api)
    
+        // runEmbedded will call the framework's showUnityWindow method internally
         ufw.runEmbedded(withArgc: CommandLine.argc, argv: CommandLine.unsafeArgv, appLaunchOpts: nil)
     }
     
     private func subviewUnity(_ window: UIWindow, _ change: NSKeyValueObservedChange<UIViewController?>) {
         if let superview = self.superview, let view = window.rootViewController?.view {
-            // the root UIViewController of Unity's UIWindow has been assigned
+            // the rootViewController of Unity's window has been assigned
             // now is the proper moment to apply our superview if we have one
             superview.addSubview(view)
             view.frame = superview.frame

--- a/sandbox/sandbox/UnityBridge.swift
+++ b/sandbox/sandbox/UnityBridge.swift
@@ -41,7 +41,7 @@ class API: NativeCallsProtocol {
     
 }
 
-class UnityBridge: UIResponder, UIApplicationDelegate, UnityFrameworkListener {
+class UnityBridge: UIResponder, UnityFrameworkListener {
  
     private static var instance : UnityBridge?
     private let ufw: UnityFramework
@@ -99,7 +99,7 @@ class UnityBridge: UIResponder, UIApplicationDelegate, UnityFrameworkListener {
         self.api.bridge = self
         self.ufw.register(self)
         FrameworkLibAPI.registerAPIforNativeCalls(self.api)
-   
+
         // runEmbedded will call the framework's showUnityWindow method internally
         self.ufw.runEmbedded(withArgc: CommandLine.argc, argv: CommandLine.unsafeArgv, appLaunchOpts: nil)
 

--- a/unityapp/Assets/Scenes/SampleScene.unity
+++ b/unityapp/Assets/Scenes/SampleScene.unity
@@ -178,6 +178,7 @@ GameObject:
   - component: {fileID: 399930887}
   - component: {fileID: 399930886}
   - component: {fileID: 399930885}
+  - component: {fileID: 399930889}
   m_Layer: 0
   m_Name: Cube
   m_TagString: Untagged
@@ -261,6 +262,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &399930889
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 399930884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea126468707174cdd9c2d17eab8d0989, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0

--- a/unityapp/Assets/Scripts/AutoRotate.cs
+++ b/unityapp/Assets/Scripts/AutoRotate.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AutoRotate : MonoBehaviour
+{
+    // Update is called once per frame
+    void Update()
+    {
+        if (Input.touchCount == 0)
+        {
+            transform.Rotate(0.0f, Time.deltaTime * 50.0f, 0.0f);
+        }
+    }
+}

--- a/unityapp/Assets/Scripts/AutoRotate.cs.meta
+++ b/unityapp/Assets/Scripts/AutoRotate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea126468707174cdd9c2d17eab8d0989
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Closes #13 

These changes are for the `old/unity2020` branch. The code in the `main` branch does not actually compose Unity into a SwiftUI element and so is not applicable to this problem/solution.

Creating a SwiftUI element that displays Unity was already accomplished by way of the container view technique; a custom `UIViewControllerRepresentable` sets Unity's internal root view as its subview. However, this is not guaranteed to always work because we don't know when and if Unity will make its root view a subview of something else internally. This is indeed the case shortly after running Unity, and it resulted in our superview getting replaced and Unity not showing.

From the README
> Between the moment you create the UnityFramework instance, and the moment you can display it, it seems like there is an issue. Some people try to add a delay, but this is definitely a hack.

In effect we have a race condition between who can apply their superview last, our code or Unity's code. We solve this problem by recognizing the fact that Unity's root view belongs to its root view controller which in turn belongs to its `UIWindow`. The window takes the role of a superview. Therefore, the superview-subview hierarchy is only established when the `rootViewController` property of the window is set (or reset). By registering an observer on this property, we can apply our superview _immediately after_ the hierarchy is complete. This ensures our desired hierarchy always takes precedence and is maintained for the duration of Unity's lifecycle.

It is also worth mentioning that as a true SwiftUI element, we can resize and reposition Unity as we see fit. Unity's own [documentation](https://docs.unity3d.com/2023.2/Documentation/Manual/UnityasaLibrary-iOS.html) says 
> Unity as a Library only supports full-screen rendering, and doesn’t support rendering on part of the screen.

which is true by default, but we have bypassed this with the container view technique. We demonstrate this with the example element `OtherUnityView`.